### PR TITLE
Changes made to deploy to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app
+web: gunicorn app:app --log-file -

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Delvr 
 is a DnD character creation application, made with Python3 and Flask as the framework and SQLAlchemy as the database ORM. 
 
-(https://github.com/mlghr/delvr/blob/tablet/home-page.jpg?raw=true)
-(https://github.com/mlghr/delvr/blob/tablet/home.jpg?raw=true)
+![landing page](https://github.com/mlghr/delvr2/blob/main/home.jpg.png?raw=true)
+
+![character info](https://github.com//mlghr/delvr2/blob/main/home-page.jpg.png?raw=true)
+
 
 # Installation
 install postgresql

--- a/app.py
+++ b/app.py
@@ -7,7 +7,8 @@ import os
 
 
 app = Flask(__name__)
-app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get('DATABASE_URL', "postgres:///dnd_db")
+# app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get('DATABASE_URL', "postgres:///dnd_db")
+app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get('DATABASE_URL', "postgres://itymgibvtouzay:7bd8ca123571e0c3caed8428e72724f65a10e39acc3a616ba08fa428aafe4bdd@ec2-54-157-12-250.compute-1.amazonaws.com:5432/dbun9evshosrda")
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.config["SQLALCHEMY_ECHO"] = True
 app.config["SECRET_KEY"] = os.environ.get('SECRET_KEY',"secret1") #heroku issue?

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.5
+python-3.7.6

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.6
+python-3.8.7


### PR DESCRIPTION
The change to the runtime.txt was guided by this doc: 

https://devcenter.heroku.com/articles/python-support#supported-runtimes

The change to the Procfile was just to enable better logging on Heroku side while deploying - because at first, when I tried deploying, the error was too cryptic:

```
2021-01-14T23:46:05.092073+00:00 heroku[web.1]: State changed from up to crashed
2021-01-14T23:46:06.984039+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=young-ridge-95240.herokuapp.com request_id=db68c97e-...-1c98ca2753ea fwd="170.247.112.222" dyno= connect= service= status=503 bytes= protocol=https
```

The most important change was to create a PostgreSQL database on Heroku and then specify its address in the `SQLALCHEMY_DATABASE_URI` config variable instead of the local database URL that was working for you on localhost.

Here's a nice tutorial on how to do this: https://medium.com/analytics-vidhya/heroku-deploy-your-flask-app-with-a-database-online-d19274a7a749